### PR TITLE
Run lint in CI and fix issues with vscode extension

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Lint
 
 on:
   pull_request:
@@ -27,6 +27,3 @@ jobs:
 
       - name: Build packages
         run: pnpm build
-
-      - name: Run tests
-        run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run Lint
+        run: pnpm lint
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,7 @@ onlyBuiltDependencies:
   - sharp
   - unrs-resolver
   - utf-8-validate
+publicHoistPattern:
+  # https://github.com/pnpm/pnpm/issues/8878#issuecomment-2546442011
+  - "@next/eslint-plugin-next"
+  - "eslint-plugin-react-hooks"

--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -9,13 +9,13 @@ export default function OAuthCallback() {
     const [oauthError, setOAuthError] = useState<string | null>(null);
     const [timedOut, setTimedOut] = useState(false);
 
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get("code");
-    const state = params.get("state");
-
     // complete the oauth flow and exchange the code for an access token
     useEffect(() => {
         const processOAuthCallback = async () => {
+            const params = new URLSearchParams(window.location.search);
+            const code = params.get("code");
+            const state = params.get("state");
+
             // the user is already authenticated, nothing to do
             if (!ready || authenticated || !code || !state) {
                 return;
@@ -35,7 +35,7 @@ export default function OAuthCallback() {
         };
 
         processOAuthCallback();
-    }, [authenticated, completeOAuth, code, ready, state]);
+    }, [authenticated, completeOAuth, ready]);
 
     // fetch the user's available entities after they've been authenticated
     useEffect(() => {


### PR DESCRIPTION
eslint was erroring when run via the vscode extension, but not via the CLI.

Didn't look too deeply into it the root cause suggests it's an issue with eslint and pnpm. I've added the suggested incantation to publicHoistPattern and it seems to work now, so I'm not asking anymore questions...